### PR TITLE
Cli args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ __pycache__
 *.html
 *.txt
 *.log
-
+*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ venv*
 __pycache__
 .env
 *.html
+*.txt
+*.log
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,30 @@ Additionally, a `.env` file is required to run the script. This is not hosted on
 # Use
 The script can be run using the command:
 ```
-python3 main.py
+python3 [options]  main.py
 ```
 Default behaviour is to pull metadata from every experiment in the [notion dashboard](https://notion.so/mzt/Capture-Exp-Plan-Raw-Data-54334d792f0545b08377c7f4221d48b0) with the "Completed" column ticked.
-However the script also accepts command line arguments. If passed any, it will search the notion dashboard's "Experimental Name" column for IDs matching the command line arguments, and pull only those entries for analysis. It is recommended to use command line arguments as the resulting figures will be less cluttered, and this method allows the user to order the experiments sensibly (as Notion databases are not ordered). For example:
+If passed any positional arguments, the program wil search the notion dashboard's "Experimental Name" column for IDs matching the command line arguments, and pull only those entries for analysis. It is recommended to use command line arguments as the resulting figures will be less cluttered, and this method allows the user to order the experiments sensibly (as Notion databases are not ordered). For example:
 ```
 python3 main.py AS_ED_01 AS_ED_02 AS_ED_07
 ```
-If the script runs successfully, it will produce a file named `out.html` which contains the rendered figures.
+Options are as follows:
+```
+-h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        Specify the name of the output file. Default is out.html
+                        (default: None)
+  -d DASHBOARD, --dashboard DASHBOARD
+                        Specify the ID of the Notion dashboard to read from
+                        (default: None)
+  -x, --exclude         Processes all experiments marked as "Completed", excluding
+                        those supplied as positional arguments (default: False)
+  --config-gen          Generate a config file named ed_data_analysis.conf with all
+                        options set to their defaults (default: False)
+  -c CONFIG, --config CONFIG
+                        Specify the name of a config file from which configuration
+                        options will be loaded. Options set in this file will
+                        always be overridden by command line arguments (default:
+                        None)
+```
+If the script runs successfully, it will produce a file named `out.html` by default which contains the rendered figures.

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,52 @@
+def ConfigGen() -> None:
+	with open("ed_data_analysis.conf", 'w', encoding="utf-8") as Writer:
+		Writer.write("""\
+#Lines beginning in a \'#\' will be ignored. Empty strings will be ignored.
+#dashboard:
+#output: out.html
+#exclude: False"""
+	       )
+
+#Dependency for LoadConfig
+def StripWhitespace(ip: str) -> str:
+	whitespace: str = " \t\n"
+	op: str = ""
+	for n in range(0, len(ip)):
+		if not (ip[n] in whitespace):
+			op += ip[n]
+	return op
+
+#Dependency for LoadConfig
+#Returns the index of the first colon in a string
+def FirstColonIndex(ip: str) -> int:
+	for n in range(0, len(ip)):
+		if ip[n] == ':':
+			return n
+	return 0
+
+def LoadConfig(config: dict) -> None:
+	#I THINK Python dictionaries get passed by reference so I should be able to modify it within this function
+	#Open config file in read mode
+	Reader: _io.TextIOWrapper = open(config["config"], "r", encoding="utf=8")
+
+	#Initialise constants for loop:
+	line: str = Reader.readline()
+
+	while line:
+		line = StripWhitespace(line)
+		#So that hashtags can be used to denote comments in the config file
+		if line[0] != '#':
+			colonIndex: int = FirstColonIndex(line)
+			key: str = line[0 : colonIndex]
+			val: str = line[colonIndex + 1 :]
+
+			if (not config[key]) and val:
+				if key == "exclude":
+					#Convert argument from string to boolean
+					config[key] = val.lower() != "false"
+				else:
+					config[key] = val
+
+		line = Reader.readline()
+
+	Reader.close()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
-from ed_analysis_manager import EDAnalysisManager
+#Import packages from pip
 from typing import Type
 import pandas as pd
 import sys
 import argparse
+
+#Import project files
+from ed_analysis_manager import EDAnalysisManager
+import config_manager
 
 #Configure argparse for handling command line arguments
 parser: argparse.ArgumentParser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -10,9 +14,21 @@ parser.add_argument("experimentIDs", action="store", help="List of experiment ID
 parser.add_argument("-o", "--output", action="store", help="Specify the name of the output file. Default is out.html")
 parser.add_argument("-d", "--dashboard", action="store", help="Specify the ID of the Notion dashboard to read from")
 parser.add_argument("-x", "--exclude", action="store_true", help="Processes all experiments marked as \"Completed\", excluding those supplied as positional arguments")
+#parser.add_argument("-i", "--id-file", action="store", help="Pass the name of a file containing experiment IDs, each on a new line")
+parser.add_argument("--config-gen", action="store_true", help="Generate a config file named ed_data_analysis.conf with all options set to their defaults")
+parser.add_argument("-c", "--config", action="store", help="Specify the name of a config file from which configuration options will be loaded. Options set in this file will always be overridden by command line arguments")
 
-#config: argparse.Namespace = parser.parse_args()
+#Actually parse command line arguments and convert from argparse.Namespace to dict
 config: dict = vars(parser.parse_args())
+
+#If the --config-gen flag is set, create the config file and exit
+if config["config_gen"]:
+	config_manager.ConfigGen()
+	sys.exit(0)
+
+#If the --config flag is set, load config options from the file
+if config["config"]:
+	config_manager.LoadConfig(config)
 
 try:
 	edAnalysis = EDAnalysisManager(config)

--- a/main.py
+++ b/main.py
@@ -7,11 +7,12 @@ import argparse
 #Configure argparse for handling command line arguments
 parser: argparse.ArgumentParser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("experimentIDs", action="store", help="List of experiment IDs to include", nargs='*')
-parser.add_argument("-o", "--output", action="store", help="Specify name out output file. Default is out.html")
+parser.add_argument("-o", "--output", action="store", help="Specify the name of the output file. Default is out.html")
 parser.add_argument("-d", "--dashboard", action="store", help="Specify the ID of the Notion dashboard to read from")
-parser.add_argument("-x", "--exclude", action="store_true", help="Processes all experiments marked as \"Completed\", excluding those supplied as positional argiments")
+parser.add_argument("-x", "--exclude", action="store_true", help="Processes all experiments marked as \"Completed\", excluding those supplied as positional arguments")
 
-config: argparse.Namespace = parser.parse_args()
+#config: argparse.Namespace = parser.parse_args()
+config: dict = vars(parser.parse_args())
 
 try:
 	edAnalysis = EDAnalysisManager(config)
@@ -19,4 +20,8 @@ except Exception as e:
 	print (e, file=sys.stderr)
 	sys.exit(1)
 
-edAnalysis.PlotData()
+try:
+	edAnalysis.PlotData()
+except Exception as e:
+	print (e, file=sys.stderr)
+	sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -7,11 +7,14 @@ import argparse
 #Configure argparse for handling command line arguments
 parser: argparse.ArgumentParser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("experimentIDs", action="store", help="List of experiment IDs to include", nargs='*')
+parser.add_argument("-o", "--output", action="store", help="Specify name out output file. Default is out.html")
+parser.add_argument("-d", "--dashboard", action="store", help="Specify the ID of the Notion dashboard to read from")
+parser.add_argument("-x", "--exclude", action="store_true", help="Processes all experiments marked as \"Completed\", excluding those supplied as positional argiments")
 
 config: argparse.Namespace = parser.parse_args()
 
 try:
-	edAnalysis = EDAnalysisManager(config.experimentIDs)
+	edAnalysis = EDAnalysisManager(config)
 except Exception as e:
 	print (e, file=sys.stderr)
 	sys.exit(1)


### PR DESCRIPTION
Switch from using sys.argv to using argparse to create a more advanced CLI.
Added functionality to:
- Specify the name of an output file
- Set the ID of a Notion dashboard
- Change the behaviour to exclude experiments with IDs matching positional arguments
- Create a default config file
- Read and parse config files